### PR TITLE
Fix Hugo v0.128+ compatibility errors

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,8 @@
 RSSLink = "feed.xml"
 baseurl = "https://daniel.town/"
 languageCode = "en-us"
-paginate = 20
+[pagination]
+pagerSize = 20
 preserveTaxonomyNames = true
 pygmentsCodefences = true
 pygmentsStyle = "native"

--- a/content/post/2018-11-26-display-black-white.md
+++ b/content/post/2018-11-26-display-black-white.md
@@ -3,7 +3,6 @@ layout: post
 title: "Seeing the screen in black and white"
 date:   2019-02-10 00:00:00
 comments: true
-published: true
 categories:
   - display
   - focus

--- a/content/post/2019-08-05-largest-mysql.md
+++ b/content/post/2019-08-05-largest-mysql.md
@@ -3,7 +3,6 @@ layout: post
 title: "Show largest mysql tables"
 date:   2019-08-05 00:00:00
 comments: true
-published: true
 categories:
   - mysql
 ---


### PR DESCRIPTION
## Summary
- Replace deprecated `paginate` config key with `[pagination] pagerSize` (deprecated in Hugo v0.128.0)
- Remove `published: true` front matter from two posts — Hugo now tries to parse `published` as a date field, and `true` is not a valid date. Posts are published by default so this field was redundant.

Fixes the build error:
```
ERROR the "published" front matter field is not a parsable date
ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0
```

## Test plan
- [ ] Verify Hugo build succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)